### PR TITLE
ci: update QC Preflight check workflow

### DIFF
--- a/.github/workflows/preflight-checker-workflow.yml
+++ b/.github/workflows/preflight-checker-workflow.yml
@@ -1,19 +1,25 @@
-name: preflight-checkers 
+name: QC Preflight Checks
+
 on:
-  pull_request_target:
-    branches: [ "main" ]
+  pull_request:
+    branches: [ main ]
   push:
-    branches: [ "main" ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  checker:
-    uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
-        repolinter: true # default: true
-        semgrep: true # default: true
-        copyright-license-detector: true # default: true
-        pr-check-emails: true # default: true
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
 
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary
- __QC Preflight Checks workflow updates__:
  - Renamed workflow to `QC Preflight Checks`

  - Changed trigger from `pull_request_target` → `pull_request` (security improvement - `pull_request_target` runs with write permissions and access to secrets, which is a security risk for untrusted PRs)
 
  - Updated reusable workflow reference to `v2` (major version upgrade)

  - Renamed job to `preflight`

  - Added job `name: Run QC Preflight Checks`

  - Updated input parameters from old format to new format:

    `enable-semgrep-scan`, `enable-dependency-review`, `enable-repolinter-check`, `enable-copyright-license-check`, `enable-commit-email-check`, `enable-commit-msg-check`, `enable-armor-checkers`

  - Removed `secrets: SEMGREP_APP_TOKEN` (no longer needed in v2)


- __New Input Parameters (Optional)__:

  - **Commit Message Check** - Ensures commit messages follow standards (optional) default set to `enable-commit-msg-check: false`
  
  - **ARMOR Compatibility Checkers** - Ensures source code follows API and ABI backward compatibility (optional) default set to `enable-armor-checkers: false`

For more information please check repo [qcom-reusable-workflow](https://github.com/qualcomm/qcom-reusable-workflows)